### PR TITLE
Refine game boot flow and audio initialization

### DIFF
--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -32,7 +32,7 @@ export class AudioManager {
   // Singleton instance
   private static instance: AudioManager;
 
-  constructor() {
+  private constructor() {
     this.logger.info(
       "AudioManager: Constructing audio manager with modular architecture"
     );

--- a/src/audio/README.md
+++ b/src/audio/README.md
@@ -49,8 +49,8 @@ The `AudioManager` acts as a facade for the entire audio system, providing a sim
 ## Usage
 
 ```typescript
-// Create an instance of AudioManager
-const audioManager = new AudioManager();
+// Retrieve the shared AudioManager instance
+const audioManager = AudioManager.getInstance();
 
 // Initialize (can be called multiple times safely)
 audioManager.initialize();

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -23,7 +23,7 @@ The core systems implement a modular architecture with the following structure:
 The central controller for the entire game.
 
 - Manages the creation and coordination of all game systems
-- Handles initialization and startup sequence
+- Handles initialization and startup sequence through a unified `boot()` flow
 - Maintains references to all major system components
 - Delegates game loop management to the GameLoop class
 - Provides dev mode options including audio control
@@ -33,14 +33,16 @@ The central controller for the entire game.
 ```typescript
 // Basic usage
 const game = new Game("gameCanvas");
-await game.init();
+await game.boot();
 game.start();
 
 // With dev mode enabled
 const game = new Game("gameCanvas", true);
+await game.boot();
 
 // With dev mode and audio enabled
 const game = new Game("gameCanvas", true, true);
+await game.boot();
 
 // Toggle audio in dev mode via console
 game.toggleDevModeAudio();

--- a/src/core/Scene.ts
+++ b/src/core/Scene.ts
@@ -91,6 +91,12 @@ export class Scene {
   /** Reference to the Game instance */
   private game: Game | null = null;
 
+  /** Cached resize handler reference */
+  private readonly resizeHandler: () => void;
+
+  /** Tracks whether the resize listener has been attached */
+  private resizeListenerAttached = false;
+
   /** Last time an asteroid was spawned (in milliseconds) */
   private lastAsteroidSpawnTime: number = 0;
 
@@ -118,6 +124,8 @@ export class Scene {
     // Store viewport dimensions
     this.width = window.innerWidth;
     this.height = window.innerHeight;
+
+    this.resizeHandler = this.onWindowResize.bind(this);
 
     // Create a new scene with solid black background
     this.scene = new THREE.Scene();
@@ -171,9 +179,6 @@ export class Scene {
 
     // Create the background manager
     this.backgroundManager = new BackgroundManager(this.scene);
-
-    // Handle window resize
-    window.addEventListener("resize", this.onWindowResize.bind(this));
 
     // Store dev mode flag
     this.devMode = devMode;
@@ -363,7 +368,10 @@ export class Scene {
     }
 
     // Remove event listeners
-    window.removeEventListener("resize", this.onWindowResize.bind(this));
+    if (this.resizeListenerAttached) {
+      window.removeEventListener("resize", this.resizeHandler);
+      this.resizeListenerAttached = false;
+    }
 
     // Clean up the background manager
     this.backgroundManager.dispose();
@@ -735,7 +743,10 @@ export class Scene {
    */
   private setupEventListeners(): void {
     // Handle window resize
-    window.addEventListener("resize", this.onWindowResize.bind(this));
+    if (!this.resizeListenerAttached) {
+      window.addEventListener("resize", this.resizeHandler);
+      this.resizeListenerAttached = true;
+    }
 
     this.logger.info("Scene: Event listeners set up");
   }

--- a/src/core/systems/AudioSystem.ts
+++ b/src/core/systems/AudioSystem.ts
@@ -1,5 +1,6 @@
 import { GameSystem } from "../GameSystem";
 import { AudioManager } from "../../audio/AudioManager";
+import { Logger } from "../../utils/Logger";
 
 /**
  * Adapter class that wraps the AudioManager class to implement the GameSystem interface.
@@ -9,11 +10,14 @@ export class AudioSystem implements GameSystem {
   /** The underlying AudioManager instance */
   private audioManager: AudioManager;
 
+  /** Logger instance */
+  private logger = Logger.getInstance();
+
   /**
    * Creates a new AudioSystem.
    */
   constructor() {
-    this.audioManager = new AudioManager();
+    this.audioManager = AudioManager.getInstance();
   }
 
   /**
@@ -27,12 +31,9 @@ export class AudioSystem implements GameSystem {
 
       // Use the new preloading function that handles optimization
       await this.audioManager.preloadEssentialAudio();
-
-      return Promise.resolve();
     } catch (error) {
-      console.error("Failed to initialize audio system:", error);
-      // Continue even if initialization fails
-      return Promise.resolve();
+      this.logger.error("Failed to initialize audio system", error);
+      throw error;
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,7 +42,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   // Initialize the game
   window.gameInstance
-    .init()
+    .boot()
     .catch((error) => {
       logger.error("Failed to initialize game:", error);
     })


### PR DESCRIPTION
## Summary
- introduce a dedicated `Game.boot()` flow that awaits optional dev tooling, centralizes normal-mode startup, and improves dev-mode audio handling
- fix `Scene` resize listener lifecycle by caching the handler, avoiding duplicate registration, and ensuring proper cleanup
- require the shared `AudioManager` singleton inside `AudioSystem`, propagate initialization failures, and update docs/tests alongside the private constructor change
- switch the app entry point to call `game.boot()` and document the new startup API

## Testing
- `npm test -- test/unit/systems/AudioSystem.test.ts`
- `npm test -- test/unit/core/Game.test.ts`
- `npm run lint` *(fails: repository does not include an ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d44ea5c78883219dc0d11d1504f39b